### PR TITLE
Arreglos generales

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -9,4 +9,8 @@ export type VsCodeApi = {
 
 declare global {
 	function acquireVsCodeApi(): VsCodeApi
+
+	interface Window {
+	    __vscodeApiInstance?: VsCodeApi
+	}
 }

--- a/src/webview/components/PupilDialog/PupilDialog.tsx
+++ b/src/webview/components/PupilDialog/PupilDialog.tsx
@@ -1,5 +1,6 @@
 import { Button, Card, CardActions, CardContent, CardHeader } from '@mui/material'
 import { createPortal } from 'react-dom'
+import { useEffect, useState } from 'react'
 
 type PupilDialogProps = {
 	open: boolean
@@ -10,6 +11,31 @@ type PupilDialogProps = {
 }
 
 const PupilDialog = ({ open, title, children, onSubmit, onCancel }: PupilDialogProps) => {
+	const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(
+		typeof window !== 'undefined' ? document.getElementById('pupil-dialog-portal') : null
+	)
+
+	useEffect(() => {
+		if (portalTarget || typeof window === 'undefined') {
+			return
+		}
+
+		const observer = new MutationObserver(() => {
+			const portal = document.getElementById('pupil-dialog-portal')
+			if (portal) {
+				setPortalTarget(portal)
+				observer.disconnect()
+			}
+		})
+
+		observer.observe(document.body, { childList: true, subtree: true })
+		return () => observer.disconnect()
+	}, [portalTarget])
+
+	if (!portalTarget) {
+		return null
+	}
+
 	return createPortal(
 		open && (
 			<>
@@ -24,8 +50,7 @@ const PupilDialog = ({ open, title, children, onSubmit, onCancel }: PupilDialogP
 				</Card>
 			</>
 		),
-
-		document.getElementById('pupil-dialog-portal')!
+		portalTarget
 	)
 }
 

--- a/src/webview/components/PupilEditor/PupilEditor.tsx
+++ b/src/webview/components/PupilEditor/PupilEditor.tsx
@@ -17,7 +17,10 @@ const PupilEditor = forwardRef<PupilEditorHandle, PupilEditorProps>(
 		const editorHeight = keyboardVisible ? '60vh' : '90vh'
 
 		return (
-			<div style={{ height: editorHeight, display: visible ? 'block' : 'none' }}>
+			<div
+				className="relative"
+				style={{ height: editorHeight, display: visible ? 'block' : 'none' }}
+			>
 				<Editor
 					theme={theme}
 					language={language}
@@ -26,6 +29,7 @@ const PupilEditor = forwardRef<PupilEditorHandle, PupilEditorProps>(
 					onMount={handleOnMount}
 					height="100%"
 				/>
+				<span id="pupil-dialog-portal" />
 			</div>
 		)
 	}

--- a/src/webview/components/PupilEditorContainer/PupilEditorContainer.tsx
+++ b/src/webview/components/PupilEditorContainer/PupilEditorContainer.tsx
@@ -38,15 +38,12 @@ const PupilEditorContainer = () => {
 				</IconButton>
 			)}
 			<div className="flex flex-col">
-				<div className="relative">
-					<PupilEditor
-						ref={editorRef}
-						keyboardVisible={keyboardVisible}
-						visible={focus === 'editor'}
-						theme={colorScheme}
-					/>
-					<span id="pupil-dialog-portal" />
-				</div>
+				<PupilEditor
+					ref={editorRef}
+					keyboardVisible={keyboardVisible}
+					visible={focus === 'editor'}
+					theme={colorScheme}
+				/>
 				<Snippets onSnippetPress={handleSnippetPress} />
 				<PupilKeyboard
 					onInput={handleKeyboardInput}

--- a/src/webview/contexts/VsCodeApiContext.tsx
+++ b/src/webview/contexts/VsCodeApiContext.tsx
@@ -6,7 +6,12 @@ const VsCodeApiContext = createContext<VsCodeApi | null>(null)
 
 export const VsCodeApiProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 	const isDev = window.location.hostname === 'localhost'
-	const vscode: VsCodeApi = isDev ? mockVsCodeApi() : acquireVsCodeApi()
+
+	let vscode: VsCodeApi = isDev
+		? mockVsCodeApi()
+		: !window.__vscodeApiInstance
+			? (window.__vscodeApiInstance = acquireVsCodeApi())
+			: window.__vscodeApiInstance
 
 	return <VsCodeApiContext.Provider value={vscode}>{children}</VsCodeApiContext.Provider>
 }


### PR DESCRIPTION
Ahora PupilDialog contempla el caso en donde todavía no está renderizado PupilEditor.

Extraje el portal dentro de PupilEditor.

Fixee un problema con VsCodeApi, había momentos donde rompía si quería llamar el context nuevamente.